### PR TITLE
(Fix) Update to current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Braintree Subscription Payments for Reaction Commerce
+
+In order to set up the braintree subscription plugin in your Reaction Commerce, follow the given steps:-
+
+1. Create an account on https://www.braintreepayments.com/. After creating an account,  you get some credential like
+
+```
+Merchant ID: xxxxxxxxxxxx
+
+Public Key: xxxxxxxxxxxxx
+
+Private Key: xxxxxxxxxxxxxxxxxx
+```
+
+
+
+2. Login in Braintree  https://www.braintreepayments.com/. and create a plan in Braintree.
+
+
+
+3. Download the braintree subscription plugin from GitHub and put it in
+ your reaction commerce
+
+```
+imports/plugins/custom
+```
+
+
+4. Run the command
+
+```
+reaction reset 
+```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Braintree Subscription Payments for Reaction Commerce
 
-In order to set up the braintree subscription plugin in your Reaction Commerce, follow the given steps:-
+In order to set up the braintree subscription plugin in your Reaction Commerce project, follow the given steps:-
 
-1. Create an account on https://www.braintreepayments.com/. After creating an account,  you get some credential like
+1. Create an account on https://www.braintreepayments.com/. After creating an account,  you will get some credentials like
 
 ```
 Merchant ID: xxxxxxxxxxxx
@@ -12,14 +12,11 @@ Public Key: xxxxxxxxxxxxx
 Private Key: xxxxxxxxxxxxxxxxxx
 ```
 
-
-
-2. Login in Braintree  https://www.braintreepayments.com/. and create a plan in Braintree.
-
+2. Login to [Braintree](https://www.braintreepayments.com/). and create a plan in Braintree.
 
 
 3. Download the braintree subscription plugin from GitHub and put it in
- your reaction commerce
+ your reaction commerce project in
 
 ```
 imports/plugins/custom

--- a/payments-braintree-subscription/lib/collections/schemas/braintreeSubscription.js
+++ b/payments-braintree-subscription/lib/collections/schemas/braintreeSubscription.js
@@ -1,4 +1,6 @@
-import { SimpleSchema } from "meteor/aldeed:simple-schema";
+import SimpleSchema from "simpl-schema";
+import { check } from "meteor/check";
+import { Tracker } from "meteor/tracker";
 import { PackageConfig } from "/lib/collections/schemas/registry";
 import { registerSchema } from "@reactioncommerce/reaction-collections";
 
@@ -11,10 +13,7 @@ import { registerSchema } from "@reactioncommerce/reaction-collections";
  *    private_key: ""
  *  see: https://developers.braintreepayments.com/javascript+node/reference
  */
-
-export const BraintreeSubscriptionPackageConfig = new SimpleSchema([
-  PackageConfig,
-  {
+export const BraintreeSubscriptionPackageConfig = PackageConfig.clone().extend({
     "settings.mode": {
       type: Boolean,
       defaultValue: false
@@ -43,7 +42,7 @@ export const BraintreeSubscriptionPackageConfig = new SimpleSchema([
       allowedValues: ["Authorize", "De-authorize", "Capture", "Refund"]
     }
   }
-]);
+);
 
 registerSchema("BraintreeSubscriptionPackageConfig", BraintreeSubscriptionPackageConfig);
 
@@ -73,6 +72,6 @@ export const BraintreeSubscriptionPayment = new SimpleSchema({
     max: 4,
     label: "CVV"
   }
-});
+}, { check, tracker: Tracker });
 
 registerSchema("BraintreeSubscriptionPayment", BraintreeSubscriptionPayment);

--- a/payments-braintree-subscription/server/methods/braintreeSubscriptionApi.js
+++ b/payments-braintree-subscription/server/methods/braintreeSubscriptionApi.js
@@ -107,9 +107,9 @@ function createSubscrioptionInBrainTree(paymentSubmitDetails){
 
   const fut = new Future();
 
-  gateway.plan.all(Meteor.bindEnvironment(function(err, result) { 
+  gateway.plan.all(Meteor.bindEnvironment(function(err, result) {
     //console.log(result.plans[0].id);
-    if(result.plans[0].id){
+    if(result.plans && result.plans.length && result.plans[0].id){
       let plan=result.plans[0].id;
       gateway.customer.create({
 
@@ -118,49 +118,49 @@ function createSubscrioptionInBrainTree(paymentSubmitDetails){
         creditCard: paymentObj.creditCard
 
       },function (err, result) {
-          //console.log(result.customer.id);
-          //console.log(result.customer.paymentMethods[0].token);
-          if(result.customer.paymentMethods[0].token){
+        //console.log(result.customer.id);
+        //console.log(result.customer.paymentMethods[0].token);
+        if(result.customer.paymentMethods[0].token){
 
-              gateway.subscription.create({
-                  paymentMethodToken: result.customer.paymentMethods[0].token,
-                  planId: plan,
-                  //trialDuration: 0,
-                  price : paymentObj.amount,
-              },(error, result) => {
-                  if(result.success){
-                    Logger.info("Subscription is created successfully");
-                  }
-                  if (error) {
-                    fut.return({
-                      saved: false,
-                      paymentType : paymentSubmitDetails.paymentType,
-                      error
-                    });
-                  } else if (!result.success) {
-                    fut.return({
-                      saved: false,
-                      paymentType : paymentSubmitDetails.paymentType,
-                      response: result
-                    });
-                  } else {
-                    //console.log(result);
-                    fut.return({
-                      saved: true,
-                      paymentType : paymentSubmitDetails.paymentType,
-                      response: result
-                    });
-                  }
-                  
+          gateway.subscription.create({
+            paymentMethodToken: result.customer.paymentMethods[0].token,
+            planId: plan,
+            //trialDuration: 0,
+            price : paymentObj.amount,
+          },(error, result) => {
+            if(result.success){
+              Logger.info("Subscription is created successfully");
+            }
+            if (error) {
+              fut.return({
+                saved: false,
+                paymentType : paymentSubmitDetails.paymentType,
+                error
               });
-          }  
+            } else if (!result.success) {
+              fut.return({
+                saved: false,
+                paymentType : paymentSubmitDetails.paymentType,
+                response: result
+              });
+            } else {
+              //console.log(result);
+              fut.return({
+                saved: true,
+                paymentType : paymentSubmitDetails.paymentType,
+                response: result
+              });
+            }
+
+          });
+        }
       });
     }
   },(error) => {
-    Reaction.Events.warn(error);
+    Logger.error("error-processing-subscription-payment", error);
   }));
   return fut.wait();
-};
+}
 
 // Create one time payment in brainTree
 
@@ -217,7 +217,7 @@ BraintreeSubsApi.apiCall.paymentSubmit = function (paymentSubmitDetails) {
 
     return createSubscrioptionInBrainTree(paymentSubmitDetails);
 
-  }  
+  }
 };
 
 


### PR DESCRIPTION
This fixes a couple of things to be compatible with version > 1.9

1. Use `simpl-schema` rather than `aldeed:simple-schema`
1. Use the Reaction `Logger` for errors
1. Add a guard to not throw a runtime error if no plans are configured

A can use this to process an order but I am still not clear how this gets attached to products.